### PR TITLE
Fix broken GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
 
-    - name: Build and Deploy
-      uses: y4code/hexo-deploy-action@master
+    - name: Hexo Deploy
+      uses: Solybum/hexo-deploy@1.0
       env:
         PERSONAL_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         PUBLISH_REPOSITORY: annkuoq/blog # The repository the action should deploy to.


### PR DESCRIPTION
`y4code/hexo-deploy-action` 已經不能用了，我改成  `Solybum/hexo-deploy`。

可以試跑看 (///▽///)